### PR TITLE
fix(issue template): add hint for logging

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -67,6 +67,8 @@ body:
         - /var/log/wifibox.log (with DEBUG logging verbosity)
         - /var/run/wifibox/appliance/log/dmesg
         - /var/run/wifibox/appliance/log/messages
+
+        Hint: The DEBUG log verbosity could be configured in the `core.conf` file, which is located in the `$LOCALBASE/etc/wifibox` directory.
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
It may not be evident for the users where the log level configuration could be found.  There is only a subtle reference for the location of the configuration files on the manual page, which may not be easy to spot.