### PR TITLE
fix(`bhyve.conf`): add syntax check for PCI pass-through configuration

### DIFF
--- a/sbin/wifibox
+++ b/sbin/wifibox
@@ -480,6 +480,11 @@ assert_daemonized() {
     fi
 }
 
+quit_daemonization() {
+    log info "VM manager: quit daemonization"
+    ${KILL} -SIGTERM $PPID
+}
+
 # shellcheck disable=SC2086
 vm_manager() {
     local _passthru_syntax
@@ -524,6 +529,7 @@ vm_manager() {
 
     if ! ${ECHO} "${passthru}" | ${GREP} -Eq "${_passthru_syntax}"; then
 	log error "bhyve.conf: malformed passthru configuration value: \"${passthru}\""
+	quit_daemonization
 	exit 3
     fi
 
@@ -566,6 +572,7 @@ vm_manager() {
 	log info "tap interface is configured: ${_tap}"
     else
 	log error "No tap interface is available, cannot proceed"
+	quit_daemonization
 	exit 5
     fi
 
@@ -573,11 +580,13 @@ vm_manager() {
 
     if [ ! -f "${_grub_cfg}" ]; then
 	log error "${_grub_cfg} could not be found, guest cannot be started"
+	quit_daemonization
 	exit 4
     fi
 
     if [ ! -f "${DISK_IMAGE}" ]; then
 	log error "${DISK_IMAGE} could not be found, guest cannot be started"
+	quit_daemonization
 	exit 4
     fi
 
@@ -664,9 +673,7 @@ vm_manager() {
 
     destroy_nmdm
     destroy_bridge
-
-    log info "VM manager: quit daemonization"
-    ${KILL} -SIGTERM $PPID
+    quit_daemonization
 }
 
 vm_stop() {

--- a/sbin/wifibox
+++ b/sbin/wifibox
@@ -432,7 +432,7 @@ destroy_vm() {
 	for ppt in ${_ppts}; do
 	    log info "Destroying bhyve PPT device: ${ppt}"
 	    if ! ${DEVCTL} clear driver -f "${ppt}" 2>&1 | capture_output debug devctl; then
-		log warn "The PPT device could not be destroyed"
+		log warn "PPT device ${ppt} could not be destroyed"
 	    fi
 	done
     else
@@ -482,6 +482,7 @@ assert_daemonized() {
 
 # shellcheck disable=SC2086
 vm_manager() {
+    local _passthru_syntax
     local _nmdm_grub_bhyve
     local _nmdm_bhyve
     local _passthru_bhyve
@@ -519,6 +520,12 @@ vm_manager() {
     . "${CONFDIR}/bhyve.conf"
 
     log debug "cpus=${cpus}, memory=${memory}, passthru=[${passthru}], console=${console}"
+    _passthru_syntax='^([[:space:]]*[0-9]{1,3}/[0-9]{1,3}/[0-9]{1,3}[[:space:]]*)*$'
+
+    if ! ${ECHO} "${passthru}" | ${GREP} -Eq "${_passthru_syntax}"; then
+	log error "bhyve.conf: malformed passthru configuration value: \"${passthru}\""
+	exit 3
+    fi
 
     if [ "${console}" = "yes" ]; then
 	_nmdm_grub_bhyve="-c ${NMDM_A}"


### PR DESCRIPTION
There was no check to ensure that the `passthru=` configuration option in the `bhyve.conf` file is in the expected format, but that was passed blindly through a sequence of commands.  Though the format is documented in the file, it cannot be safely assumed that it will be given properly, possibly by mistake.

At the same time, use this opportunity to provide a better error message for the user and cause less frustration.

Fixes #82