### PR TITLE
fix(`wifibox`): be more adaptive about the location of the `vmm` kernel module

### DIFF
--- a/sbin/wifibox
+++ b/sbin/wifibox
@@ -13,13 +13,17 @@ CONFDIR=${PREFIX}/etc/wifibox
 WIFIBOX_LOG=${LOGDIR}/wifibox.log
 UDS_CONFIG=${CONFDIR}/appliance/uds_passthru.conf
 
+: "${SYSCTL:=/sbin/sysctl}"
+: "${SED:=/usr/bin/sed}"
+
+KERNEL_PATH=$(${SYSCTL} -n kern.module_path | ${SED} -E 's/^([^;]*);.*/\1/')
+
 : "${BHYVE:=/usr/sbin/bhyve}"
 : "${BHYVECTL:=/usr/sbin/bhyvectl}"
-: "${VMM_KO:=/boot/kernel/vmm.ko}"
+: "${VMM_KO:=${KERNEL_PATH}/vmm.ko}"
 : "${DEVCTL:=/usr/sbin/devctl}"
 : "${DAEMON:=/usr/sbin/daemon}"
 : "${IFCONFIG:=/sbin/ifconfig}"
-: "${SYSCTL:=/sbin/sysctl}"
 : "${KLDLOAD:=/sbin/kldload}"
 : "${KLDUNLOAD:=/sbin/kldunload}"
 : "${KLDSTAT:=/sbin/kldstat}"
@@ -32,7 +36,6 @@ UDS_CONFIG=${CONFDIR}/appliance/uds_passthru.conf
 : "${PS:=/bin/ps}"
 : "${PRINTF:=/usr/bin/printf}"
 : "${GREP:=/usr/bin/grep}"
-: "${SED:=/usr/bin/sed}"
 : "${TAIL:=/usr/bin/tail}"
 : "${HEAD:=/usr/bin/head}"
 : "${SLEEP:=/bin/sleep}"


### PR DESCRIPTION
It is not always the case that the kernel modules are located under the `/boot/kernel` directory.  For custom kernels, that is something else (though usually somewhere within `/boot`) which makes the script fail to function properly.

On initialization, query the currently lodaded kernel itself about the path of its accompaining modules and use that information for finding `vmm(4)`.

Fixes #86