### PR TITLE
feat(`wifibox`): remove explicit management of `nmdm(4)` devices

### DIFF
--- a/man/wifibox.8
+++ b/man/wifibox.8
@@ -1,4 +1,4 @@
-.Dd March 2, 2024
+.Dd August 11, 2024
 .Dt WIFIBOX 8
 .Os
 .Sh NAME
@@ -8,17 +8,17 @@
 .Nm
 .Cm start
 .Oo
-.Cm guest | Cm netif | Cm console | Cm vmm
+.Cm guest | Cm netif | Cm vmm
 .Oc
 .Nm
 .Cm stop
 .Oo
-.Cm guest | Cm netif | Cm console | Cm vmm
+.Cm guest | Cm netif | Cm vmm
 .Oc
 .Nm
 .Cm restart
 .Oo
-.Cm guest | Cm netif | Cm console | Cm vmm
+.Cm guest | Cm netif | Cm vmm
 .Oc
 .Nm
 .Cm status
@@ -233,9 +233,6 @@ Guest only, maintain the console device and the networking interface.
 Networking interface and guest.  That latter is required because the
 networking interface is bound to the virtual machine that runs the
 guest.
-.It Cm console
-Null-modem device and guest.  That latter is required because the
-null-modem device is bound to the virtual machine that runs the guest.
 .It Cm vmm
 The
 .Xr vmm 4
@@ -245,7 +242,7 @@ interface.
 .Pp
 The commands are as follows.
 .Bl -tag -width -indent
-.It Cm start Oo Cm guest | Cm netif | Cm console | Cm vmm Oc
+.It Cm start Oo Cm guest | Cm netif | Cm vmm Oc
 Start
 .Nm .
 By default, the
@@ -257,7 +254,7 @@ on the same device must not be configured.  Note that the
 target can work only if
 .Sy wifibox0
 networking interface has already been created.
-.It Cm stop Oo Cm guest | Cm netif | Cm console | Cm vmm Oc
+.It Cm stop Oo Cm guest | Cm netif | Cm vmm Oc
 Stop
 .Nm .
 Without the
@@ -267,7 +264,7 @@ parameter, the
 interface is destroyed and the guest is detached from the configured
 PCI wireless network device.  After that, the FreeBSD driver is free
 to take over the device.
-.It Cm restart Oo Cm guest | Cm netif | Cm console | Cm vmm Oc
+.It Cm restart Oo Cm guest | Cm netif | Cm vmm Oc
 Restart
 .Nm ,
 which is the sequential composition of the
@@ -277,14 +274,10 @@ and
 commands by default. The
 .Cm guest
 parameter is for the guest only.  This is recommended for applying
-system-level updates to the guest. The
+system-level updates to the guest.  The
 .Cm netif
 parameter is to recreate the networking interface and restart the
 guest.  The
-.Cm console
-parameter recreate the null-modem device and restarts the guest.  This
-is recommended when the console support is turned on in the
-configuration.  The
 .Cm vmm
 parameter is to restart the guest while reloading the
 .Xr vmm 4
@@ -302,8 +295,7 @@ Attach to the running guest with
 through a virtual serial port, implemented by
 .Xr nmdm 4 .
 This is recommended for troubleshooting problems with the guest in an
-interactive fashion.  It can also be used to perform updates, install
-or remove packages.  This has to be configured specifically in order
+interactive fashion.  This has to be configured specifically in order
 to work.  The actual way of logging into the system as an
 administrator depends on the VM image in use.  Most of the time the
 .Sy root

--- a/sbin/wifibox
+++ b/sbin/wifibox
@@ -21,6 +21,7 @@ KERNEL_PATH=$(${SYSCTL} -n kern.module_path | ${SED} -E 's/^([^;]*);.*/\1/')
 : "${BHYVE:=/usr/sbin/bhyve}"
 : "${BHYVECTL:=/usr/sbin/bhyvectl}"
 : "${VMM_KO:=${KERNEL_PATH}/vmm.ko}"
+: "${NMDM_KO:=${KERNEL_PATH}/nmdm.ko}"
 : "${DEVCTL:=/usr/sbin/devctl}"
 : "${DAEMON:=/usr/sbin/daemon}"
 : "${IFCONFIG:=/sbin/ifconfig}"
@@ -28,7 +29,6 @@ KERNEL_PATH=$(${SYSCTL} -n kern.module_path | ${SED} -E 's/^([^;]*);.*/\1/')
 : "${KLDUNLOAD:=/sbin/kldunload}"
 : "${KLDSTAT:=/sbin/kldstat}"
 : "${SHA256:=/sbin/sha256}"
-: "${MKNOD:=/sbin/mknod}"
 : "${NICE:=/usr/bin/nice}"
 
 : "${CAT:=/bin/cat}"
@@ -46,6 +46,7 @@ KERNEL_PATH=$(${SYSCTL} -n kern.module_path | ${SED} -E 's/^([^;]*);.*/\1/')
 : "${CU:=/usr/bin/cu}"
 : "${NETSTAT:=/usr/bin/netstat}"
 : "${READLINK:=/usr/bin/readlink}"
+: "${LS:=/bin/ls}"
 
 : "${GRUB_BHYVE:=${LOCALBASE}/sbin/grub-bhyve}"
 : "${SOCAT:=${LOCALBASE}/bin/socat}"
@@ -146,9 +147,19 @@ sysctl_value() {
     ${SYSCTL} -nq "$1"
 }
 
+get_kmod_path() {
+    local _kmod="$1"
+
+    ${KLDSTAT} -v -n "${_kmod}" \
+	| ${TAIL} +2 \
+	| ${HEAD} -1 \
+	| ${SED} -e 's![^(]*(\([^)]*\))!\1!'
+}
+
 assert_kmod_loaded() {
     local _kmod="$1"
     local _kmod_file
+    local _kmod_path
 
     if [ -n "$2" ]; then
 	_kmod_file="$2"
@@ -156,7 +167,20 @@ assert_kmod_loaded() {
 	_kmod_file="${_kmod}"
     fi
 
-    log debug "assert loaded: kmod=${_kmod}, kmod_file=${_kmod_file}"
+    log debug "Check location: kmod=${_kmod}, kmod_file=${_kmod_file}"
+
+    if ${KLDSTAT} -q -m "${_kmod}"; then
+	_kmod_path="$(get_kmod_path "${_kmod}")"
+	log info "${_kmod}.ko is expected at path: ${_kmod_file}"
+	log info "${_kmod}.ko is found at path: ${_kmod_path}"
+
+	if [ "${_kmod_path}" != "${_kmod_file}" ] && ! ${KLDUNLOAD} "${_kmod}"; then
+	    log error "${_kmod}.ko is loaded from a different location, but cannot be replaced"
+	    exit 127
+	fi
+    fi
+
+    log debug "Assert loaded: kmod=${_kmod}, kmod_file=${_kmod_file}"
 
     if ! ${KLDSTAT} -q -m "${_kmod}"; then
 	log debug "Kernel module ${_kmod} is not loaded"
@@ -170,30 +194,12 @@ assert_kmod_loaded() {
     fi
 }
 
-get_kmod_path() {
-    local _kmod="$1"
-
-    ${KLDSTAT} -v -n "${_kmod}" \
-	| ${TAIL} +2 \
-	| ${HEAD} -1 \
-	| ${SED} -e 's![^(]*(\([^)]*\))!\1!'
+assert_vmm_loaded() {
+    assert_kmod_loaded "vmm" "${VMM_KO}"
 }
 
-assert_vmm_loaded() {
-    local _kmod_path
-
-    if ${KLDSTAT} -q -m vmm; then
-	_kmod_path="$(get_kmod_path vmm)"
-	log info "vmm.ko is expected at path: ${VMM_KO}"
-	log info "vmm.ko is found at path: ${_kmod_path}"
-
-	if [ "${_kmod_path}" != "${VMM_KO}" ] && ! ${KLDUNLOAD} vmm; then
-	    log error "vmm.ko is loaded from a different location, but cannot be replaced"
-	    exit 127
-	fi
-    fi
-
-    assert_kmod_loaded "vmm" "${VMM_KO}"
+assert_nmdm_loaded() {
+    assert_kmod_loaded "nmdm" "${NMDM_KO}"
 }
 
 # shellcheck disable=SC2046
@@ -221,13 +227,58 @@ get_image_checksum() {
     ${SHA256} -q "${DISK_IMAGE}"
 }
 
-check_configuration() {
-    local _file="$1"
+load_bhyve_conf_values() {
+    local _config="${CONFDIR}/bhyve.conf"
 
-    if [ ! -f "${_file}" ]; then
-	log error "${_file} is missing, please create it from the sample"
+    if [ ! -f "${_config}" ]; then
+	log error "${_config} is missing, please create it from the sample"
 	exit 3
     fi
+
+    # Internal defaults
+    cpus=1
+    memory=128M
+    passthru=
+    console=no
+    priority=50
+
+    log info "Pulling bhyve options from configuration file"
+    # shellcheck source=./etc/bhyve.conf.sample
+    . "${CONFDIR}/bhyve.conf"
+
+    log debug "cpus=${cpus}"
+    log debug "memory=${memory}"
+    log debug "passthru=[${passthru}]"
+    log debug "console=${console}"
+    log debug "priority=${priority}"
+
+    _max_vmm_cpus=$(${SYSCTL} -n hw.vmm.maxcpu)
+
+    log debug "bhyve max cpus=${_max_vmm_cpus}"
+
+    assert_value_ranged_integer \
+	"bhyve.conf" "cpus" 1 "${_max_vmm_cpus}" \
+	"${cpus}"
+
+    assert_value_wellformed \
+	"bhyve.conf" "memory" \
+	'^[[:space:]]*[0-9]+([Kk]|[Mm]|[Gg]|[Tt])?[[:space:]]*$' \
+	"non-negative integer, suffixed with unit: K, M, G, T" \
+	"${memory}"
+
+    assert_value_wellformed \
+	"bhyve.conf" "passthru" \
+	'^([[:space:]]*[0-9]{1,3}/[0-9]{1,3}/[0-9]{1,3}[[:space:]]*)*$' \
+	"list of slot/bus/function, triples of non-negative integers" \
+	"${passthru}"
+
+    assert_value_yesno \
+	"bhyve.conf" "console" \
+	"${console}"
+
+    assert_value_ranged_integer \
+	"bhyve.conf" "priority" 0 99 \
+	"${priority}"
 }
 
 has_bridge_interface() {
@@ -279,40 +330,6 @@ destroy_bridge() {
     else
 	log warn "No linked tap inteface found for ${WIFIBOX_IF}"
     fi
-}
-
-create_nmdm() {
-    check_configuration "${CONFDIR}/bhyve.conf"
-
-    # shellcheck source=./etc/bhyve.conf.sample
-    . "${CONFDIR}/bhyve.conf"
-
-    [ "${console}" != "yes" ] && return 0
-
-    log info "Bringing up null-modem devices for console connection"
-    assert_kmod_loaded "nmdm"
-
-    [ ! -c ${NMDM_A} ] && ${MKNOD} ${NMDM_A} 2>&1 | capture_output debug mknod
-    [ ! -c ${NMDM_B} ] && ${MKNOD} ${NMDM_B} 2>&1 | capture_output debug mknod
-
-    [ ! -c ${NMDM_A} ] && log warn "${NMDM_A} is not available"
-    [ ! -c ${NMDM_B} ] && log warn "${NMDM_B} is not available"
-
-    [ -c ${NMDM_A} ] && [ -c ${NMDM_B} ] \
-	&& log info "Null-modem devices are available"
-}
-
-destroy_nmdm() {
-    log info "Removing null-modem devices"
-
-    [ -c ${NMDM_A} ] && ${RM} ${NMDM_A} 2>&1 | capture_output debug rm
-    [ -c ${NMDM_B} ] && ${RM} ${NMDM_B} 2>&1 | capture_output debug rm
-
-    [ -c ${NMDM_A} ] && log warn "${NMDM_A} could not be removed"
-    [ -c ${NMDM_B} ] && log warn "${NMDM_B} could not be removed"
-
-    [ ! -c ${NMDM_A} ] && [ ! -c ${NMDM_B} ] \
-	&& log info "Null-modem devices are removed"
 }
 
 find_guest_ip() {
@@ -406,11 +423,7 @@ uds_passthru_stop() {
 }
 
 get_ppt_devices() {
-    check_configuration "${CONFDIR}/bhyve.conf"
-    passthru=
-
-    # shellcheck source=./etc/bhyve.conf.sample
-    . "${CONFDIR}/bhyve.conf"
+    load_bhyve_conf_values
 
     if [ -z "${passthru}" ]; then
 	${ECHO} ""
@@ -564,55 +577,11 @@ vm_manager() {
     log info "VM manager launched"
     log info "Gathering necessary configuration files for launching the guest"
 
-    check_configuration "${CONFDIR}/bhyve.conf"
-
-    cpus=1
-    memory=128M
-    passthru=
-    console=no
-    priority=50
-
-    log info "Pulling bhyve options from configuration file"
-    # shellcheck source=./etc/bhyve.conf.sample
-    . "${CONFDIR}/bhyve.conf"
-
-    log debug "cpus=${cpus}"
-    log debug "memory=${memory}"
-    log debug "passthru=[${passthru}]"
-    log debug "console=${console}"
-    log debug "priority=${priority}"
-
-    _max_vmm_cpus=$(${SYSCTL} -n hw.vmm.maxcpu)
-
-    log debug "bhyve max cpus=${_max_vmm_cpus}"
-
-    assert_value_ranged_integer \
-	"bhyve.conf" "cpus" 1 ${_max_vmm_cpus} \
-	"${cpus}"
-
-    assert_value_wellformed \
-	"bhyve.conf" "memory" \
-	'^[[:space:]]*[0-9]+([Kk]|[Mm]|[Gg]|[Tt])?[[:space:]]*$' \
-	"non-negative integer, suffixed with unit: K, M, G, T" \
-	"${memory}"
-
-    assert_value_wellformed \
-	"bhyve.conf" "passthru" \
-	'^([[:space:]]*[0-9]{1,3}/[0-9]{1,3}/[0-9]{1,3}[[:space:]]*)*$' \
-	"list of slot/bus/function, triples of non-negative integers" \
-	"${passthru}"
-
-    assert_value_yesno \
-	"bhyve.conf" "console" \
-	"${console}"
-
-    assert_value_ranged_integer \
-	"bhyve.conf" "priority" 0 99 \
-	"${priority}"
-
+    load_bhyve_conf_values
     _nice_priority=$(${EXPR} \( ${priority} \* 40 / 99 \) - 20)
 
     if [ "${console}" = "yes" ]; then
+	assert_nmdm_loaded
 	_nmdm_grub_bhyve="-c ${NMDM_A}"
 	_nmdm_bhyve="-l com1,${NMDM_A}"
 	log info "Guest console is configured to use"
@@ -752,7 +721,6 @@ vm_manager() {
 
     [ -n "${_restart}" ] && exit 1
 
-    destroy_nmdm
     destroy_bridge
     quit_daemonization
 }
@@ -807,9 +775,8 @@ wifibox_start() {
     case ${_target} in
 	guest) _start="G";;
 	""|netif) _start="GN";;
-	console) _start="GM";;
 	vmm) _start="GV";;
-	*) log error "Unknown target: ${_target} (supported: guest, netif, console, vmm)"
+	*) log error "Unknown target: ${_target} (supported: guest, netif, vmm)"
 	   exit 1;;
     esac
 
@@ -826,16 +793,8 @@ wifibox_start() {
 	show_progress
     fi
 
-    if has_flag "${_start}" "M"; then
-	create_nmdm
-	show_progress
-    fi
-
     if has_flag "${_start}" "G"; then
 	assert_vm_can_run
-
-	create_nmdm
-	show_progress
 
 	vm_start
 	show_progress
@@ -862,9 +821,8 @@ wifibox_stop() {
     case ${_target} in
 	guest) _stop="G";;
 	""|netif) _stop="GN";;
-	console) _stop="GM";;
 	vmm) _stop="GV";;
-	*) log error "Unknown target: ${_target} (supported: guest, netif, console, vmm)"
+	*) log error "Unknown target: ${_target} (supported: guest, netif, vmm)"
 	   exit 1;;
     esac
 
@@ -876,14 +834,6 @@ wifibox_stop() {
 	show_progress
 
 	vm_stop
-	show_progress
-
-	destroy_nmdm
-	show_progress
-    fi
-
-    if has_flag "${_stop}" "M"; then
-	destroy_nmdm
 	show_progress
     fi
 
@@ -944,9 +894,8 @@ wifibox_restart() {
     case ${_target} in
 	guest) _restart="G";;
 	""|netif) _restart="GN";;
-	console) _restart="GM";;
 	vmm) _restart="GV";;
-	*) log error "Unknown target: ${_target} (supported: guest, netif, console, vmm)"
+	*) log error "Unknown target: ${_target} (supported: guest, netif, vmm)"
 	   exit 1;;
     esac
 
@@ -957,11 +906,6 @@ wifibox_restart() {
 	uds_passthru_stop
 	show_progress
 	vm_stop
-	show_progress
-    fi
-
-    if has_flag "${_restart}" "M"; then
-	destroy_nmdm
 	show_progress
     fi
 
@@ -977,11 +921,6 @@ wifibox_restart() {
 
     if has_flag "${_restart}" "N"; then
 	create_bridge
-	show_progress
-    fi
-
-    if has_flag "${_restart}" "M"; then
-	create_nmdm
 	show_progress
     fi
 
@@ -1025,7 +964,7 @@ wifibox_console() {
 	exit 127
     fi
 
-    if [ ! -c ${NMDM_B} ]; then
+    if ! ${LS} "${NMDM_DEVICE}"* > /dev/null 2>&1; then
 	log error "No null-modem device is configured"
 	exit 127
     fi
@@ -1053,9 +992,9 @@ wifibox_version() {
 wifibox_usage() {
     ${CAT} <<EOF
 USAGE: ${SCRIPT} ...
-    start [guest|netif|console|vmm]
-    stop [guest|netif|console|vmm]
-    restart [guest|netif|console|vmm]
+    start [guest|netif|vmm]
+    stop [guest|netif|vmm]
+    restart [guest|netif|vmm]
     status
     console
     version


### PR DESCRIPTION
Character devices under the governance of the `nmdm(4)` driver are created on demand on first access therefore it does not make sense to check for their presence and remove them based on the response. Similarly, this behavior of null-modem devices makes it unncessary to create them explicitly before `wifibox` gets to use them.

In addition to that, removing existing `nmdm(4)` devices ahead of time externally causes the kernel module fail to unload.  This is clearly a bug in the base system itself, but let us reduce the chances and simplify the code of `wifibox` itself.

Remove both the `create_nmdm` and `destroy_nmdm` functions as well as the option to restart the console, as an attached functionality.

Fixes #104