### PR TITLE
fix(`wifibox`): correctly terminate the VM by sending `SIGTERM`

### DIFF
--- a/sbin/wifibox
+++ b/sbin/wifibox
@@ -44,6 +44,7 @@ KERNEL_PATH=$(${SYSCTL} -n kern.module_path | ${SED} -E 's/^([^;]*);.*/\1/')
 : "${KILL:=/bin/kill}"
 : "${RM:=/bin/rm}"
 : "${CU:=/usr/bin/cu}"
+: "${TR:=/usr/bin/tr}"
 : "${NETSTAT:=/usr/bin/netstat}"
 : "${READLINK:=/usr/bin/readlink}"
 : "${LS:=/bin/ls}"
@@ -99,7 +100,7 @@ log() {
 	*) return 0;;
     esac
 
-    _level="$(${PRINTF} "%-5s" "${_type}" | tr "[:lower:]" "[:upper:]")"
+    _level="$(${PRINTF} "%-5s" "${_type}" | ${TR} "[:lower:]" "[:upper:]")"
 
     if [ -w ${WIFIBOX_LOG} ]; then
 	${ECHO} "${_timestamp} ${_level} ${_message}" >> ${WIFIBOX_LOG}
@@ -135,10 +136,10 @@ check_virtfs() {
 
     _backends=$(${BHYVE} -s help)
     log debug "Backends reported by bhyve:"
-    echo "${_backends}" | capture_output debug bhyve
+    ${ECHO} "${_backends}" | capture_output debug bhyve
 
     if ! (${ECHO} "${_backends}" | ${GREP} -Fq virtio-9p); then
-        log error "The Virtio 9p (VirtFS) bhyve interface is not available"
+	log error "The Virtio 9p (VirtFS) bhyve interface is not available"
 	exit 127
     fi
 }
@@ -321,15 +322,19 @@ destroy_bridge() {
 
     _tap="$(get_tap_interface)"
 
-    log info "Destroying bridge interface: ${WIFIBOX_IF}"
-    ${IFCONFIG} ${WIFIBOX_IF} destroy 2>&1 | capture_output debug ifconfig
-
     if [ -n "${_tap}" ]; then
+	log info "Unlinking tap interface from ${WIFIBOX_IF}: ${_tap}"
+	${IFCONFIG} ${WIFIBOX_IF} deletem "${_tap}" 2>&1 | capture_output debug ifconfig
+
 	log info "Destroying linked tap interface: ${_tap}"
 	${IFCONFIG} "${_tap}" destroy 2>&1 | capture_output debug ifconfig
     else
 	log warn "No linked tap inteface found for ${WIFIBOX_IF}"
     fi
+
+    log info "Destroying bridge interface: ${WIFIBOX_IF}"
+    ${IFCONFIG} ${WIFIBOX_IF} destroy 2>&1 | capture_output debug ifconfig
+
 }
 
 find_guest_ip() {
@@ -396,8 +401,8 @@ uds_passthru_start() {
 	_mode="${s##*mode=}"; _mode="${_mode%%,*}"
 
 	if [ -z "${_port}" ]; then
-           log warn "No port defined for ${_path}, dropping UDS pass-through"
-	   continue
+	    log warn "No port defined for ${_path}, dropping UDS pass-through"
+	    continue
 	fi
 
 	log info "Hooking up ${_ip}:${_port} as ${_path} (${_user}:${_group}@${_mode})"
@@ -448,7 +453,7 @@ destroy_vm() {
     if [ -n "${_ppts}" ]; then
 	for ppt in ${_ppts}; do
 	    log info "Destroying bhyve PPT device: ${ppt}"
-	    if ! ${DEVCTL} clear driver -f "${ppt}" 2>&1 | capture_output debug devctl; then
+	    if ! (${DEVCTL} clear driver -f "${ppt}" 2>&1 | capture_output debug devctl); then
 		log warn "PPT device ${ppt} could not be destroyed"
 	    fi
 	done
@@ -468,7 +473,7 @@ vm_start() {
     fi
 
     ${DAEMON} -r -t "${VM_MANAGER_DAEMON_ID}" \
-	      "${0}" _manage_vm
+	"${0}" _manage_vm
 
     log info "Waiting for bhyve to start up"
 
@@ -499,7 +504,7 @@ assert_daemonized() {
 
 quit_daemonization() {
     log info "VM manager: quit daemonization"
-    ${KILL} -SIGTERM $PPID
+    ${KILL} -TERM $PPID
 }
 
 assert_value_wellformed() {
@@ -509,7 +514,7 @@ assert_value_wellformed() {
     local _expected="$4"
     local _value="$5"
 
-    if ! ${ECHO} "${_value}" | ${GREP} -Eq "${_syntax}"; then
+    if ! (${ECHO} "${_value}" | ${GREP} -Eq "${_syntax}"); then
 	log error "${_location}: malformed ${_name} value: \"${_value}\", expected: ${_expected}"
 	quit_daemonization
 	exit 3
@@ -596,7 +601,7 @@ vm_manager() {
 	for sbf in ${passthru}; do
 	    _passthru_bhyve="${_passthru_bhyve} -s 6:${_slot},passthru,${sbf}"
 	    _slot=$(${EXPR} ${_slot} + 1)
-        done
+	done
 
 	log info "Passthru devices configured: [${passthru}]"
     else
@@ -703,9 +708,12 @@ vm_manager() {
 
     log debug "Nice priority: ${_nice_priority}"
     log debug "Arguments: ${_bhyve_args}"
+
     ${NICE} -n ${_nice_priority} \
 	    ${BHYVE} ${_bhyve_args} 2>&1 | capture_output debug bhyve
+
     _bhyve_exit_code="$?"
+
     destroy_vm
 
     case "${_bhyve_exit_code}" in
@@ -721,24 +729,28 @@ vm_manager() {
 
     [ -n "${_restart}" ] && exit 1
 
-    destroy_bridge
     quit_daemonization
 }
 
 vm_stop() {
     local _ppt
     local _pid
+    local _gpid
 
     _pid="$(get_vm_manager_pid)"
 
-    if [ -z "${_pid}" ]; then
+    if [ -n "${_pid}" ]; then
+	_gpid="$(${PS} -o pgid -p "${_pid}" | ${TAIL} -1 | ${GREP} -o '[0-9]*')"
+    fi
+
+    log info "Stopping guest ${WIFIBOX_VM}, managed by PID [${_pid}], GPID [${_gpid}]"
+
+    if [ -z "${_gpid}" ]; then
 	log warn "Guest is not running, hence not stopped"
 	return 1
     fi
 
-    log info "Stopping guest ${WIFIBOX_VM}, managed by PID ${_pid}"
-
-    if ! (${KILL} -SIGTERM "${_pid}" 2>&1 | capture_output debug kill); then
+    if ! (${KILL} -TERM -"${_gpid}" 2>&1 | capture_output debug kill); then
 	log warn "Guest could not be stopped gracefully"
     fi
 


### PR DESCRIPTION
Previously, a `kill -SIGTERM` would be requested of the daemon, which would forward the signal to /usr/local/sbin/wifibox. /usr/local/sbin/wifibox would not forward the signal to bhyve, which requires the signal to shutdown cleanly.

Also explicitly unlink the tap interface from the wifibox interface, and wait 5 seconds instead of 3 for the VM to shutdown.

Also consistently use subshells.