### PR TITLE
feat(`wifibox`): adaptively wait on stopping the guest

### DIFF
--- a/etc/bhyve.conf.sample
+++ b/etc/bhyve.conf.sample
@@ -30,3 +30,10 @@ passthru=
 # be set in the range of 0 to 99, where 0 is the highest possible
 # priority while 99 is the lowest.
 priority=50
+
+# The maximal length of the grace period for waiting the bhyve(8)
+# process to exit on signalling ACPI power-off.  This is in seconds,
+# approximately, within the range of 1 to 60.  If the guest does not
+# stop after the period is over, a forceful shutdown is attempted,
+# which might leave the hardware in inconsistent state.
+stop_wait_max=10

--- a/sbin/wifibox
+++ b/sbin/wifibox
@@ -242,6 +242,7 @@ load_bhyve_conf_values() {
     passthru=
     console=no
     priority=50
+    stop_wait_max=10
 
     log info "Pulling bhyve options from configuration file"
     # shellcheck source=./etc/bhyve.conf.sample
@@ -252,6 +253,7 @@ load_bhyve_conf_values() {
     log debug "passthru=[${passthru}]"
     log debug "console=${console}"
     log debug "priority=${priority}"
+    log debug "stop_wait_max=${stop_wait_max}"
 
     _max_vmm_cpus=$(${SYSCTL} -n hw.vmm.maxcpu)
 
@@ -280,6 +282,10 @@ load_bhyve_conf_values() {
     assert_value_ranged_integer \
 	"bhyve.conf" "priority" 0 99 \
 	"${priority}"
+
+    assert_value_ranged_integer \
+	"bhyve.conf" "stop_wait_max" 1 60 \
+	"${stop_wait_max}"
 }
 
 has_bridge_interface() {
@@ -440,6 +446,10 @@ get_ppt_devices() {
 
 get_vm_manager_pid() {
     ${PGREP} -fx "daemon: ${VM_MANAGER_DAEMON_ID}\[[0-9]*\]"
+}
+
+get_vm_pid() {
+    ${PGREP} -fx "bhyve: ${WIFIBOX_VM}"
 }
 
 destroy_vm() {
@@ -736,6 +746,7 @@ vm_stop() {
     local _ppt
     local _pid
     local _gpid
+    local _vm_pid
 
     _pid="$(get_vm_manager_pid)"
 
@@ -750,14 +761,26 @@ vm_stop() {
 	return 1
     fi
 
+    load_bhyve_conf_values
+
     if ! (${KILL} -TERM -"${_gpid}" 2>&1 | capture_output debug kill); then
 	log warn "Guest could not be stopped gracefully"
+    else
+	for i in $(seq 1 ${stop_wait_max}); do
+	    _vm_pid=$(get_vm_pid)
+
+	    log info "Check if the guest is still running [${i}/${stop_wait_max}]: ${_vm_pid}"
+
+	    if [ -z "${_vm_pid}" ]; then
+		log info "Guest has stopped.  All good!"
+		return 0
+	    fi
+
+	    ${SLEEP} 1 2>&1 | capture_output debug sleep
+	done
     fi
 
-    log info "Waiting 3 seconds for the guest to stop"
-    ${SLEEP} 3 2>&1 | capture_output debug sleep
-
-    log info "Forcing shutdown of guest ${WIFIBOX_VM}"
+    log info "Grace period over, forcing shutdown of guest ${WIFIBOX_VM}"
     ${BHYVECTL} --force-poweroff --vm=${WIFIBOX_VM} 2>&1 | capture_output debug bhyvectl
     destroy_vm
 }


### PR DESCRIPTION
The static 3-second timeout for waiting the guest on stop may not be enough for the guest to complete its shutdown sequence.  This can be important for letting the guest to run certain tear-down functions and prevent from leaving the hardware in an troublesome state.

Instead, after the `TERM` signal is sent to initiate the graceful termination of the guest, periodically check back on its state for a while (configurable by the user, defaults to 10 seconds) and either consider it stopped or make an attempt to forcefully stop the guest to avoid the infinite wait.

This is also some form of mitigation of the bug that was uncovered in 95312ad5.  Previously the forceful shutdown was always executed because the ACPI power-off did not work.  But with that change, it now often becomes unnecessary and it actually leads to a race condition and error with bhyvectl(8).