### PR TITLE
fix(`wifibox`): ensure suspended before notifying the system to suspend

### DIFF
--- a/devd/wifibox.conf.sample
+++ b/devd/wifibox.conf.sample
@@ -7,5 +7,6 @@
 notify 11 {
 	match "system"		"ACPI";
 	match "subsystem"	"Suspend";
-	action "service wifibox suspend && /etc/rc.suspend acpi $notify";
+	action "service wifibox suspend";
+	action "/etc/rc.suspend acpi $notify";
 };

--- a/devd/wifibox.conf.sample
+++ b/devd/wifibox.conf.sample
@@ -5,7 +5,7 @@
 # the file has been created.
 #
 notify 11 {
-        match "system"          "ACPI";
-        match "subsystem"       "Suspend";
-        action "/etc/rc.suspend acpi $notify && service wifibox suspend";
+	match "system"		"ACPI";
+	match "subsystem"	"Suspend";
+	action "service wifibox suspend && /etc/rc.suspend acpi $notify";
 };


### PR DESCRIPTION
Previously, the system would likely be suspended in the middle of the stopping of the VM (if using `RECOVER_SUSPEND_VMM` or `RECOVER_SUSPEND_GUEST` for example), meaning critical tasks like the removing of the PCI devices and unloading of the VMM module were executed after a _resume_, not before a suspension.

Also, remove the superfluous call to /etc/rc.suspend. By default, this script is executed by a devd rule of a lower priority _after_ this rule is executed.