### PR TITLE
chore(`devd`): make inclusion of the configuration extension optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ CHMOD=/bin/chmod
 GZIP=/usr/bin/gzip
 GIT=$(LOCALBASE)/bin/git
 SHELLCHECK=$(LOCALBASE)/bin/shellcheck
+UNAME=/usr/bin/uname
 
 .if !defined(VERSION)
 VERSION!=	$(GIT) describe --tags --always
@@ -26,6 +27,17 @@ VERSION!=	$(GIT) describe --tags --always
 _GUEST_MAN=	${GUEST_MAN}
 .else
 _GUEST_MAN=	../man8/wifibox.8.gz
+.endif
+
+.if !defined(DEVD_FIX)
+_FREEBSD_VERSION!=	$(UNAME) -U
+
+.if $(_FREEBSD_VERSION) > 1400089
+DEVD_FIX=	#
+.else
+DEVD_FIX=	please
+.endif
+
 .endif
 
 SUB_LIST=	PREFIX=$(PREFIX) \
@@ -57,9 +69,12 @@ install:
 
 	$(MKDIR) -p $(ETCDIR)/wifibox
 	$(CP) -R etc/* $(ETCDIR)/wifibox/
+
+.if defined(DEVD_FIX)
 	$(MKDIR) -p $(ETCDIR)/devd
 	$(SED) ${_SUB_LIST_EXP} devd/wifibox.conf.sample \
 		> $(ETCDIR)/devd/wifibox.conf.sample
+.endif
 
 	$(MKDIR) -p $(RCDIR)
 	$(SED) ${_SUB_LIST_EXP} rc.d/wifibox > $(RCDIR)/wifibox

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ mostly recommended for development and testing.
     LOCALBASE=<prefix of the grub2-bhyve and socat packages> \
     GUEST_ROOT=<guest disk image location> \
     GUEST_MAN=<guest manual page location> \
-    RECOVERY_METHOD=<method to use on suspend and resume>
+    RECOVERY_METHOD=<method to use on suspend and resume> \
+    DEVD_FIX=<add extra devd.conf(5) configuration to handle suspend>
 ```
 
 By default, `PREFIX` is set to `/usr/local`.  In addition to that, it
@@ -124,6 +125,15 @@ Wifibox should be revived on a suspend/resume pair of events.
   reverse on resume.
 - The recovery mechanism itself could be disabled by setting this
   value to be empty.
+
+The `DEVD_FIX` variable controls the deployment of a fix for handling
+the ACPI suspend event.  In older FreeBSD versions, suspend will not
+automatically trigger a call for the `service wifibox suspend` command
+so that has to be explicitly configured.  This has been added for
+FreeBSD 14.0 hence it is not required any more from that version
+onwards.  Set it to an empty value to disable this fix, otherwise the
+default value is going to be determined based on the OS version where
+the build is run.
 
 ## Documentation
 

--- a/man/wifibox.8
+++ b/man/wifibox.8
@@ -1,4 +1,4 @@
-.Dd August 11, 2024
+.Dd September 22, 2024
 .Dt WIFIBOX 8
 .Os
 .Sh NAME
@@ -200,12 +200,14 @@ otherwise the link will stop working.
 .Pp
 In addition to that, because a
 .Xr devd.conf 5
-file is installed as part of the application,
+file might be installed as part of the application,
 .Xr devd 8
-must be restarted so the additional configuration file can be read.
-These bits are responsible to managing the recovery in case of
-suspend/resume events.  When this feature is not in use, this step
-may be omitted.
+may have to be restarted so the additional configuration file can be
+read.  These bits are responsible to managing the recovery in case of
+suspend/resume events.  When this feature is not in use, or not
+required, for example, for
+.Fx 14.0
+or later, this step may be safely omitted.
 .Bd -literal -offset indent
 # service devd restart
 .Ed


### PR DESCRIPTION
FreeBSD versions starting from 14.0 can now properly trigger the `suspend` action for `rc(8)` scripts [1] hence the workaround for that is no longer needed.  Implement an automated detection of this feature in the build process and lose the fix depending on the OS version.

Note that since the original change in `src` did not bump the `__FreeBSD_version`, it is not possible to tell exactly if the userland has the necessary support.  Thus an approximate version is used to err on the side of caution.  Fortunately, that is not a problem if the suspension logic is run twice, because that is idempotent.

Fixes #120

[1] https://github.com/freebsd/freebsd-src/commit/2cf8ef5910fd3754f8021f9c67fde6b9d9030f33