### PR TITLE
fix(`wifibox`): avoid race conditions on restarting the guest

### DIFF
--- a/sbin/wifibox
+++ b/sbin/wifibox
@@ -64,8 +64,6 @@ WIFIBOX_VM="wifibox"
 UDS_PASSTHRU_DAEMON_ID="wifibox-uds-passthru"
 VM_MANAGER_DAEMON_ID="wifibox-vm-manager"
 
-VMM_VM_PATH="/dev/vmm/${WIFIBOX_VM}"
-
 log() {
     local _type="$1"
     local _level
@@ -446,11 +444,20 @@ get_ppt_devices() {
     fi
 }
 
+get_vm_manager_pid() {
+    ${PGREP} -fx "daemon: ${VM_MANAGER_DAEMON_ID}\[[0-9]*\]"
+}
+
 get_vm_pid() {
     ${PGREP} -fx "bhyve: ${WIFIBOX_VM}"
 }
 
 destroy_vm() {
+    log info "Destroying guest ${WIFIBOX_VM}"
+
+    ${BHYVECTL} --destroy --vm=${WIFIBOX_VM} 2>&1 | capture_output info bhyvectl
+    ${SLEEP} 0.5 2>&1 | capture_output debug sleep
+
     _ppts="$(get_ppt_devices)"
 
     log info "Destroying bhyve PPT devices: [${_ppts}]"
@@ -466,9 +473,6 @@ destroy_vm() {
     else
 	log warn "No bhyve PPT device could be found"
     fi
-
-    log info "Destroying guest ${WIFIBOX_VM}"
-    ${BHYVECTL} --destroy --vm=${WIFIBOX_VM} 2>&1 | capture_output info bhyvectl
 }
 
 vm_start() {
@@ -744,6 +748,7 @@ vm_manager() {
 vm_stop() {
     local _ppt
     local _pid
+    local _manager_pid
 
     _pid="$(get_vm_pid)"
 
@@ -762,20 +767,33 @@ vm_stop() {
 	for i in $(seq 1 ${stop_wait_max}); do
 	    _pid=$(get_vm_pid)
 
-	    log info "Check if the guest is still running [${i}/${stop_wait_max}]: ${_pid}"
+	    log info "Check if the guest is still running [${i}/${stop_wait_max}]: [${_pid}]"
 
-	    if [ -z "${_pid}" ] && [ ! -c "${VMM_VM_PATH}" ]; then
+	    if [ -z "${_pid}" ]; then
 		log info "Guest has stopped.  All good!"
-		return 0
+		break
 	    fi
 
 	    ${SLEEP} 1 2>&1 | capture_output debug sleep
 	done
     fi
 
-    log info "Grace period over, forcing shutdown of guest ${WIFIBOX_VM}"
-    ${BHYVECTL} --force-poweroff --vm=${WIFIBOX_VM} 2>&1 | capture_output debug bhyvectl
-    destroy_vm
+    if [ -n "${_pid}" ]; then
+	log info "Grace period is over, forcing shutdown of guest ${WIFIBOX_VM}"
+	${BHYVECTL} --force-poweroff --vm=${WIFIBOX_VM} 2>&1 | capture_output debug bhyvectl
+    fi
+
+    while true; do
+	_manager_pid=$(get_vm_manager_pid)
+	log info "Waiting for the manager to clean up: [${_manager_pid}]"
+
+	if [ -z "${_manager_pid}" ]; then
+	    log info "The manager has finished.  Perfect!"
+	    break
+	fi
+
+	${SLEEP} 1 2>&1 | capture_output debug sleep
+    done
 }
 
 show_progress() {


### PR DESCRIPTION
The `ppt` driver cannot be cleared until the VM runs so move the respective `devctl(8)` call back to the end of `destroy_vm`. Restore the wait period after the VM is destroyed to make sure that the device is released.

More importantly, do not let `vm_stop` to call `destroy_vm` but leave it the VM manager to take care of the clean-up tasks.  The VM manager should be unblocked to do that after the guest either stops by itself (due to the ACPI power-off event) or forcefully stopped.  In addition to that, wait for the VM manager to stop too, because it should not be launched again (on a different thread) until all the clean-up tasks have been completed.