### PR TITLE
docs: add the FreeBSD Journal article

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Wifibox tries to implement as a single easy-to-use software package.
 
 - A workaround is supplied for laptops to support suspend/resume.
 
+For more information on the background and the high-level overview of
+Wifibox, please read the [article] in the November/December 2024
+edition of the FreeBSD Journal on Virtualization.
+
 ## Warning
 
 *This is a work-in-progress experimental software project without any
@@ -187,3 +191,4 @@ configuration added here!
 [`net/wpa_supplicant_gui`]: https://cgit.freebsd.org/ports/tree/net/wpa_supplicant_gui
 [`grub2-bhyve`]: https://github.com/grehan-freebsd/grub2-bhyve
 [`socat`]: http://www.dest-unreach.org/socat/
+[article]: https://github.com/pgj/freebsd-wifibox/releases/download/freebsd-journal-2024-06/freebsd-journal-wifibox.pdf


### PR DESCRIPTION
After the presentation at EuroBSDcon 2024, I was invited to write an article on Wifibox for the [FreeBSD Journal](https://freebsdfoundation.org/our-work/journal/).  I accepted the opportunity and the article was published in the [November/December 2024 edition](https://freebsdfoundation.org/our-work/journal/browser-based-edition/virtualization-2/) of the journal, a special issue on Virtualization. This article is now being added as part of the documentation for the project.