### PR TITLE
fix(`wifibox)`: silence `kldstat(8)` error messages on built-in modules

### DIFF
--- a/sbin/wifibox
+++ b/sbin/wifibox
@@ -152,7 +152,7 @@ sysctl_value() {
 get_kmod_path() {
     local _kmod="$1"
 
-    ${KLDSTAT} -v -n "${_kmod}" \
+    ${KLDSTAT} -v -n "${_kmod}" 2> /dev/null \
 	| ${TAIL} +2 \
 	| ${HEAD} -1 \
 	| ${SED} -e 's![^(]*(\([^)]*\))!\1!'


### PR DESCRIPTION
The `get_kmod_path()` function lets `kldstat(8)` emit its warning when details of a module is queried but it is built into the kernel, for example:

```console
kldstat: can't find file nmdm: No such file or directory
```

Mute all the error messages because only the return value is used and it is empty on errors anyway.