### PR TITLE
fix: do not keep the manager running when the guest is terminated

### DIFF
--- a/sbin/wifibox
+++ b/sbin/wifibox
@@ -729,6 +729,7 @@ vm_manager() {
 	   _restart=yes;;
 	1) log info "VM manager: guest was powered off, signaling exit";;
 	2) log info "VM manager: guest was halted, signaling exit";;
+	143) log info "VM manager: guest was terminated but did not power off, signaling exit";;
 	*) log info "VM manager: guest crashed, signaling restart after 5 seconds"
 	   log debug "exit_code=${_bhyve_exit_code}"
 	   ${SLEEP} 5 2>&1 | capture_output debug sleep


### PR DESCRIPTION
Sometimes the guest causes `bhyve` to return exit code 143 when `SIGTERM` is sent to it.  This is not currently handled in the manager so it tries to keep restarting the non-existing guest. On the main thread, the manager is waited for completion and the whole situation leads to an infinite loop inside at the end.

Add a case for handling the missing exit code and consider that a scenario when no restart is needed and let the manager shut down.